### PR TITLE
FEAT_expPage

### DIFF
--- a/fe_ipb_page/src/components/pages/storeproduct/StoreExp.jsx
+++ b/fe_ipb_page/src/components/pages/storeproduct/StoreExp.jsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { logInState } from '../../state/loginState';
+import styles from './StoreExp.module.css';
+
+function StoreExp() {
+  const [storeProductData, setStoreProductData] = useState([]);
+  const [logInData, setLogInData] = useRecoilState(logInState);
+  const [additionalData, setAdditionalData] = useState([]);
+
+  const today = new Date();
+  const year = today.getFullYear();
+  // 
+  const month = String(today.getMonth() + 1).padStart(2, '0'); 
+  const day = String(today.getDate()).padStart(2, '0');
+  const todayDate = `${year}-${month}-${day}`;
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const fetchData = async () => {
+    try {
+      const response = await fetch(`http://43.202.9.215:8080/storeproduct/list/${logInData.store_id}`);
+      const data = await response.json();
+
+      // 현재 날짜와 마이너스 연산하여 expDataCalculate에 저장
+      const addData = data.map((item) => ({
+        ...item,
+        addData: subtractDates(todayDate, item.exp),
+      }));
+
+      setStoreProductData(addData);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // 날짜 간의 차이 계산 함수
+  const subtractDates = (date1, date2) => {
+    const oneDay = 24 * 60 * 60 * 1000; // 1일을 밀리초로 변환
+    const diffDays = Math.round((new Date(date2) - new Date(date1)) / oneDay);
+    return diffDays;
+  };
+
+  // 추가 데이터를 저장하는 함수
+  const saveAdditionalData = (data) => {
+    setAdditionalData([...additionalData, data]);
+  };
+
+  return (
+    <>
+    <h2>유통기한 관리</h2>
+      <p>오늘 날짜는 {todayDate} 입니다. </p>
+
+      <div className={styles.policyStatement}>
+        <div>
+          <p className={styles.redExp}></p>
+          <p>:유통기한 지남</p>
+        </div>
+        <div>
+          <p className={styles.yellowExp}></p>
+          <p>:D-3</p>
+        </div>
+        <div>
+          <p className={styles.greenExp}></p>
+          <p>:D-5</p>
+        </div>
+        <div>
+          <p className={styles.blueExp}></p>
+          <p>:D-7</p>
+        </div>
+      </div>
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>SKU Code</th>
+            <th>상품 이름</th>
+            <th>재고</th>
+            <th>판매가</th>
+            <th>유통기한</th>
+            <th className={styles['exp-column']}>유통기한연산</th>
+            <th>유통기한연산CSS</th>
+          </tr>
+        </thead>
+        <tbody>
+        {storeProductData.map((item) => {
+          if (item.addData <= 7) {
+            return (
+              <tr key={item.id}>
+                <td>{item.product_code}</td>
+                <td>
+                  <Link to={`/product/detail/${item.id}`}>{item.product_name}</Link>
+                </td>
+                <td>{item.qnt}</td>
+                <td>{item.price}</td>
+                <td>
+                  {item.addData <= -1 && (
+                    <p className={styles.redExp}></p>
+                  )}
+                  {item.addData > -1 && item.addData <= 3 && (
+                    <p className={styles.yellowExp}></p>
+                  )}
+                  {item.addData > 3 && item.addData <= 5 && (
+                     <p className={styles.greenExp}></p>
+                  )}
+                  {item.addData > 5 && item.addData <= 7 && (
+                      <p className={styles.blueExp}></p>
+                  )}
+                  {item.addData > 7 && <span>{item.addData}</span>}
+                  {item.exp}</td>
+                <td>
+                  {item.addData}
+                </td>
+                <td>
+                {item.addData <= -1 && (
+                    <p className={styles.redExp}></p>
+                  )}
+                  {item.addData > -1 && item.addData <= 3 && (
+                    <p className={styles.yellowExp}></p>
+                  )}
+                  {item.addData > 3 && item.addData <= 5 && (
+                     <p className={styles.greenExp}></p>
+                  )}
+                  {item.addData > 5 && item.addData <= 7 && (
+                      <p className={styles.blueExp}></p>
+                  )}
+                  {item.addData > 7 && <span>{item.addData}</span>}
+                </td>
+              </tr>
+            );
+  } else {
+    return null; // Skip rendering the item if item.addData is greater than 7
+  }})}
+        </tbody>
+      </table>
+
+      {/* 추가 데이터 저장 버튼 */}
+      {/* <button onClick={() => saveAdditionalData('Additional Data')}>Save Additional Data</button> */}
+
+      {/* 저장된 추가 데이터 출력 */}
+      {/* <ul>
+        {additionalData.map((data, index) => (
+          <li key={index}>{data}</li>
+        ))}
+      </ul> */}
+    </>
+  );
+}
+
+export default StoreExp;

--- a/fe_ipb_page/src/components/pages/storeproduct/StoreExp.module.css
+++ b/fe_ipb_page/src/components/pages/storeproduct/StoreExp.module.css
@@ -1,0 +1,84 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  /* padding: 8px; */
+  padding: 10px;
+  border-bottom: 1px solid #e4e4e4;
+  border-radius: 10px;
+}
+
+.table th {
+  background-color: #FFFFFF;
+  font-weight: bold;
+  padding: 18px;
+}
+
+.table th:first-child,
+.table td:first-child {
+  text-align: center;
+}
+
+.table th:last-child,
+.table td:last-child {
+  text-align: right;
+}
+
+.table tbody tr:hover {
+  background-color: #FAFAFA;
+}
+
+.exp-column {
+  background-color: tomato;
+}
+
+.policyStatement {
+  display: flex;
+  align-items: center;
+}
+
+.policyStatement > div {
+  display: flex;
+  align-items: center;
+  margin-right: 16px;
+}
+
+.policyStatement > div > p {
+  margin-left: 8px;
+}
+
+.redExp {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: red;
+}
+
+.yellowExp {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: yellow;
+}
+
+.greenExp {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: green;
+}
+
+.blueExp {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: blue;
+}
+

--- a/fe_ipb_page/src/layouts/Header.js
+++ b/fe_ipb_page/src/layouts/Header.js
@@ -67,9 +67,13 @@ const Header = () => {
                   <DropdownItem>
                     <Link to="/storeproductlist">보유 상품</Link>
                   </DropdownItem>
+                  <DropdownItem>
+                    <Link to="/storeexp">유통기한 관리</Link>
+                  </DropdownItem>
                   {/* <DropdownItem>Option 2</DropdownItem>
                   <DropdownItem divider />
                   <DropdownItem>Reset</DropdownItem> */}
+                  
                 </DropdownMenu>
               </UncontrolledDropdown>
 

--- a/fe_ipb_page/src/routes/Router.js
+++ b/fe_ipb_page/src/routes/Router.js
@@ -96,6 +96,7 @@ const ProductDetail = lazy(() => import("../components/pages/product/ProductDeta
 const Event = lazy(() => import("../components/pages/event/Event.jsx"))
 const Orders = lazy(() => import("../components/pages/order/Orders.jsx"))
 const StoreProductList01 = lazy(() => import("../components/pages/storeproduct/StoreProductList.jsx"))
+const StoreExp = lazy(() => import("../components/pages/storeproduct/StoreExp.jsx"))
 const OrderList = lazy(() => import("../components/pages/order/OrderList.jsx"))
 const Store = lazy(() => import("../components/pages/store/Store.jsx"))
 const StoreAdd = lazy(() => import("../components/pages/store/StoreAdd.jsx"))
@@ -137,6 +138,7 @@ const ThemeRoutes = [
       { path: "/event", exact: true, element: <Event /> },
       { path: "/order", exact: true, element: <Orders /> },
       { path: "/storeproductlist", exact: true, element: <StoreProductList01 /> },
+      { path: "/storeexp", exact: true, element: <StoreExp /> },
       { path: "/orderslist", exact: true, element: <OrderList /> },
       { path: "/store", exact: true, element: <Store /> },
       { path: "/store/add", exact: true, element: <StoreAdd /> },


### PR DESCRIPTION
 점포 재고 상품에 유통기한으로 관리 하는 페이지 입니다.

헤더 네브에 상품관리쪽에 유통기한 관리라는걸 만들고 그걸 누르면 /storeexp로 들어감
유통기한 관리는 skuCode, 재고수량, 판매가 유통기한이 있고
유통기한이 지났으면 빨강 3일 남았으면 노랑 5일 남았으면 초록, 7일 남았으면 파랑으로 표기한다.

오늘 날짜인 'todayDate' 라는 변수를 만들어 2023-05-22 형식의 YYYY-MM-DD로 받아오는 데이터 값이랑 맞춰준다
맞춰준 데이터와 날짜 차이 계산 함수 subtractDates()로 연산을 하고 그 연산한 데이터를 
그 데이터를 setStoreProductData에 추가를 해준 setStoreProductData에 업데이트 해줘 .map으로 같이 받아 올 수 있게해준다.